### PR TITLE
feature/implement-stringify-pascal-case

### DIFF
--- a/gwx_core/utils/stringify.py
+++ b/gwx_core/utils/stringify.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 
 def file_name_conversion(file_path: str, extension_to_remove=None) -> str:
@@ -21,3 +22,19 @@ def file_name_conversion(file_path: str, extension_to_remove=None) -> str:
         return str.lower(str(name.split(extension_to_remove)[0]))
 
     return str.lower(str(name))
+
+
+def pascal_case(word: str) -> str:
+    """
+    Convert passed words to pascal case, ie:
+
+    - pascal_case("San Francisco")  # SanFrancisco
+    - pascal_case("SAN-FRANCISCO")  # SanFrancisco
+    - pascal_case("san_francisco")  # SanFrancisco
+
+    :param word: passed word as string
+    :return: the converted string
+    """
+    word_regex_pattern = re.compile("[^A-Za-z]+")
+    words = word_regex_pattern.split(word)
+    return "".join(w.title() if i is 0 else w.title() for i, w in enumerate(words))

--- a/tests/utils/stringify_test.py
+++ b/tests/utils/stringify_test.py
@@ -7,6 +7,7 @@ class StringifyTest(UtilsTestCase):
 
     def setUp(self) -> None:
         self.stub = f'{os.path.abspath(os.getcwd())}/../stubs/file_stub.py'
+        self.stub_name = 'file_stub'
 
     def test_file_name_conversion_successfully(self) -> None:
         """Assert that the file name from an absolute path has been extracted,
@@ -27,7 +28,7 @@ class StringifyTest(UtilsTestCase):
         file_name = stringify.file_name_conversion(self.stub, '_stub')
         self.assertEqual('file', file_name)
 
-    def test_file_name_conversion_raise_exception(self):
+    def test_file_name_conversion_raise_exception(self) -> None:
         """Assert that the FileNotFoundError exception is raised,
         when a non existing file is submitted as parameter.
 
@@ -39,3 +40,12 @@ class StringifyTest(UtilsTestCase):
             stringify.file_name_conversion(non_existing_file)
 
         self.assertEqual(f'Error file: {non_existing_file} does not exists.', str(context.exception))
+
+    def test_pascal_case_successful(self) -> None:
+        """Assert that the pascal case handles conversion of words separated by underscores `_` or spaces ` `.
+
+        :return: None
+        """
+        self.assertEqual('FileFile', stringify.pascal_case(f'{self.stub_name[:-4]} {self.stub_name[:-4]}'))
+        self.assertEqual('File', stringify.pascal_case(self.stub_name[:-4]))
+        self.assertEqual('FileStub', stringify.pascal_case(self.stub_name))


### PR DESCRIPTION
- Added the `pascal_case` method to handle string conversion to
`PascalCase` preferrably used for class naming